### PR TITLE
Possible fix for eval server-crashing

### DIFF
--- a/app/controllers/client.coffee
+++ b/app/controllers/client.coffee
@@ -72,7 +72,7 @@ module.exports = class Client
     command = parse str
 
     if command.verb == 'eval' and player.programmer
-      code = command.argstr.replace(/\\\{/g, '{').replace(/\\\}/g, '}')
+      code = if command.argstr? then command.argstr.replace(/\\\{/g, '{').replace(/\\\}/g, '}') else ''
       context.runEval @db, player, code
     else if command.verb in ['logout', 'quit']
       player = connections.playerFor @socket


### PR DESCRIPTION
Problem was, when submitting "eval", it gets parsed into verb + args, where args end up all being undefined. Solution is to just check to make sure args isn't undefined before calling things like .replace, etc. This also makes sense as to why ` wasn't throwing an error, since it gets parsed as a special into "eval " (note the trailing space), which got picked up as verb eval + blank (non-undefined) args.
