### PR TITLE
Add default .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+PORT=8888
+LOG_LEVEL=trace
+MAINTENANCE_MODE=false
+USER_DB_FILE=demo/users.json
+WORLD_DIRECTORY=demo/world

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 /state
-.env
 bin
 /coverage
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
     - node_modules
 install:
   - npm install
+  - rm .env
   - ln -s .env.test .env
 
 script: "npm run lint && npm test && npm run cover && npm run coveralls"


### PR DESCRIPTION
Currently `npm start` fails with `Error: ENOENT: no such file or directory, open '.env'` so probably is a good idea to just have a default .env variable.
Maybe it was in the .gitignore for some reason that I´m not aware, so in that case just close the PR. 