### PR TITLE
lint: don't escape fwd-slash inside character class

### DIFF
--- a/src/lib/fs-db.js
+++ b/src/lib/fs-db.js
@@ -49,7 +49,7 @@ class FsDb {
 
   setupWatcher() {
     this.watcher = chokidar.watch(this.directory, {
-      ignored: /[\/\\]\./,
+      ignored: /[/\\]\./,
       persistent: true,
     });
 


### PR DESCRIPTION
Travis CI build failed due to a lint issue. Regex normally needs you to escape forward slash, but not inside `[...]`.