### PR TITLE
Add the list of options to the socket protocol for multiple characters

### DIFF
--- a/src/controllers/user-controller.js
+++ b/src/controllers/user-controller.js
@@ -99,11 +99,14 @@ class UserController extends BaseChildController {
       this.loginPlayer(players[0].id)
     } else if (players.length > 1) {
       const msg = ['Choose a character to play as:']
-      const inputs = [{ type: 'text', label: 'character', name: 'selection' }]
+      const options = []
 
       players.forEach((p, i) => {
         msg.push(`${i + 1}. #cmd[${p.name}]`)
+        options.push(p.name)
       })
+
+      const inputs = [{ type: 'text', label: 'character', name: 'selection', options }]
 
       this.emit('output', msg.join('\n'))
       this.emit('request-input', inputs, reply => {

--- a/test/blackbox/authenticated-test.js
+++ b/test/blackbox/authenticated-test.js
@@ -167,7 +167,8 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
+                                 options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 
@@ -197,7 +198,8 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
+                                 options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 
@@ -227,7 +229,8 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
+                                 options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 

--- a/test/blackbox/authenticated-test.js
+++ b/test/blackbox/authenticated-test.js
@@ -257,7 +257,7 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+      const expectedInputs = [ { type: 'text', label: 'character', options: [ 'test', 'bob' ], name: 'selection' } ]
 
       t.deepEqual(inputs, expectedInputs)
 
@@ -287,7 +287,7 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+      const expectedInputs = [ { type: 'text', label: 'character', options: [ 'test', 'bob' ], name: 'selection' } ]
 
       t.deepEqual(inputs, expectedInputs)
 

--- a/test/blackbox/authenticated-test.js
+++ b/test/blackbox/authenticated-test.js
@@ -167,8 +167,7 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
-                                 options: ['test', 'bob'] } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 
@@ -198,8 +197,7 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
-                                 options: ['test', 'bob'] } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 
@@ -229,8 +227,7 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
     t.equal(actual, expected)
 
     socket.once('request-input', (inputs, send) => {
-      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', 
-                                 options: ['test', 'bob'] } ]
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection', options: ['test', 'bob'] } ]
 
       t.deepEqual(inputs, expectedInputs)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,17 +2320,17 @@ stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
-strip-ansi@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  dependencies:
-    ansi-regex "^3.0.0"
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A small suggestion that would allow graphical clients or bots to handle the list of options in an easier, without having to wait for and parse the (formatted) output : minimalist, non-breaking change for text-only clients.

For the record, for what is worth, I have finally pushed my (rough) bot here:
https://github.com/Omikhleia/room.js-bot

(Not using this feature yet, so selection is currently hard-coded)

