### PR TITLE
Fix remaining _ in demo and docs

### DIFF
--- a/demo/world/areas/city/treehouse/announce.js
+++ b/demo/world/areas/city/treehouse/announce.js
@@ -10,7 +10,7 @@ function announce(viewFn = views.noOp, sender, msg) {
   });
   // ... and propagate down.
   this.exits.down.announce((senderx, recipient, message) => {
-    if (recipient !== items_oaktree) {
+    if (recipient !== items.oaktree) {
       return color.gray('(From the tree) ') + viewFn(senderx, recipient, message);
     }
     return null;

--- a/demo/world/items/builderstaff/buildAction.js
+++ b/demo/world/items/builderstaff/buildAction.js
@@ -21,7 +21,7 @@ function buildAction(player, direction) {
   }
 
   // Build room
-  const idScheme = 'areas_instances_room';
+  const idScheme = 'areas.instances.room';
   const id = nextId(idScheme);
 
   const created = lib.room.new(id);

--- a/demo/world/items/builderstaff/cloneAction.js
+++ b/demo/world/items/builderstaff/cloneAction.js
@@ -22,7 +22,7 @@ function cloneAction(player, argstr) {
   }
 
   // Now, we can proceed to CREATION
-  const idScheme = 'instances_' + target.id.split('_').pop();
+  const idScheme = 'instances.' + target.id.split('.').pop();
   const created = target.clone(idScheme);
 
   // Special flag to track objects created with the staff.

--- a/demo/world/items/oaktree/climb.js
+++ b/demo/world/items/oaktree/climb.js
@@ -1,5 +1,5 @@
 function climb({ player, dobj, iobj, verbstr, argstr, dobjstr, prepstr, iobjstr }) {
-  const destination = areas_city_treehouse;
+  const destination = areas.city.treehouse;
   if (this.location.canLeave(player) && destination.canEnter(player)) {
     this.location.doLeave(player, 'up');
     player.location = destination;

--- a/demo/world/items/oaktree/tell.js
+++ b/demo/world/items/oaktree/tell.js
@@ -1,7 +1,7 @@
 function tell(msg) {
   // Propagate up the tree
   if (msg !== null) {
-    areas_city_treehouse.contents.forEach(recipient => {
+    areas.city.treehouse.contents.forEach(recipient => {
       recipient.tell(color.gray('(From the ground) ') + msg);
     });
   }

--- a/demo/world/lib/door/canEnter.js
+++ b/demo/world/lib/door/canEnter.js
@@ -1,6 +1,6 @@
 function canEnter(player) {
   if (this.closed) {
-    // From lib_closeable
+    // From lib.closeable
     player.tell(`The ${this.name} is closed.`);
     return false;
   }

--- a/demo/world/lib/npcs/seller/orderGood.js
+++ b/demo/world/lib/npcs/seller/orderGood.js
@@ -14,7 +14,7 @@ function order({ player, dobj, iobj, verbstr, argstr, dobjstr, prepstr, iobjstr 
     player.tell(`${this.name} says: "You are welcome!"`);
 
     // Clone the good
-    const created = target.clone('instances_' + target.id.split('_').pop());
+    const created = target.clone('instances.' + target.id.split('.').pop());
 
     if (this !== player) {
       // Give to player

--- a/doc/CUSTOMIZING.md
+++ b/doc/CUSTOMIZING.md
@@ -6,7 +6,7 @@ This guide is intended for administrators and game builders, when setting up the
 We will deal here with both the object identifiers and the underlying on-disk file hierarchy, as there is a one-to-one mapping between them -- For details, refer to the [Programming guide](PROGRAMMING.md):
 
 > Identifiers are internally mapped to a file path by the DB, with the underscore character
-> corresponding to the path separator (e.g. "lib\_room" will be mapped to "lib/room"). This allows
+> corresponding to the path separator (e.g. "lib.room" will be mapped to "lib/room"). This allows
 > organizing the objects logically -- You can create objects at any level, but it is a **good practice**
 >to enquire your game administrator regarding the recommended naming scheme.
 
@@ -29,12 +29,12 @@ The **system** object is where several customizable hooks are defined (besides a
 | Customizable hook    | comment |
 | -------------------- | ------- |
 | onServerStarted | Invoked when the server just started -- The demonstration does nothing here, but that's where you can implement any (re)initialization logic. |
-| onPlayerCreated | Invoked when a new player character is created: this is where you can define his/her initial location and the appropriate trait(s) for the player object. (It comes with none by default, so you have do define it -- The demonstration uses **lib\_player** from its mudlib.) |
-| onPlayerConnected | Invoked when a player character enters the world: this is where you can restore his/her previous location, and possibly announce his/her arrival to other players (at least in the room, if not to all) -- The demonstration relies on the doEnter() method, from the mudlib **lib\_room** object, and obviously refers to a demonstration-specific initial location. |
+| onPlayerCreated | Invoked when a new player character is created: this is where you can define his/her initial location and the appropriate trait(s) for the player object. (It comes with none by default, so you have do define it -- The demonstration uses **lib.player** from its mudlib.) |
+| onPlayerConnected | Invoked when a player character enters the world: this is where you can restore his/her previous location, and possibly announce his/her arrival to other players (at least in the room, if not to all) -- The demonstration relies on the doEnter() method, from the mudlib **lib.room** object, and obviously refers to a demonstration-specific initial location. |
 | onPlayerDisconnected | Invoked when a player character quits the world: this is where you can reset his/her location, and possibly announce his/her leaving to other players (at least in the room, if not to all). |
 | onPlayerCommandFailed | Invoked when a player command could not be matched: this is where you can possibly interpret the failure reason, allowing for more precise messages and game-specific decisions, suggesting help, etc. |
 
-For the record here, as far as customizable hooks are concerned, the game engine also invokes onTabKeyPress() on the player object when the TAB key event is received. In the demonstration, this is used to cycle through the different modes (a.k.a. PLAY, CHAT, SAY, EVAL), and implemented in the **lib\_player** object.
+For the record here, as far as customizable hooks are concerned, the game engine also invokes onTabKeyPress() on the player object when the TAB key event is received. In the demonstration, this is used to cycle through the different modes (a.k.a. PLAY, CHAT, SAY, EVAL), and implemented in the **lib.player** object.
 
 ## Useful objects (recommended)
 The following objects are not mandatory *per se* but are probably best keeping (and customized, if need really be).
@@ -48,7 +48,7 @@ The following objects are not mandatory *per se* but are probably best keeping (
 
 ## Mudlib objects (replaceable)
 
-In the demonstration, all mudlib objects are located under the *lib/* directory (and henceforth, their identifiers all start with "lib\_").
+In the demonstration, all mudlib objects are located under the *lib/* directory (and henceforth, their identifiers all start with "lib.").
 
 The mudlib defines an initial class hierarchy for designing more complex objects, for details see the [Demonstration mudlib](DEMO_MUDLIB.md) memorandum.
 
@@ -66,8 +66,8 @@ For the record, player accounts (i.e. login credentials etc.) are stored in anot
 All other objects are demonstration-specific, so you may wholly remove them when creating your own game. As noted, you may follow any convention and logical naming scheme for your world, but you will likely want to manage the objects in a maintenable way. 
 
 For instance, the demonstration adopts the following scheme:
-- All useable items are located in *items/* (and therefore have identifiers starting with "items\_"),
-- Rooms are structured under *areas/* (and therefore have identifiers such as "areas\_something\_roomname").
+- All useable items are located in *items/* (and therefore have identifiers starting with "items."),
+- Rooms are structured under *areas/* (and therefore have identifiers such as "areas.something.roomname").
 - Cloned objects (i.e. copies of useable items, such as made by the seller NPCs) are located in *instances/*.
 
 Once you have created a room of your own, and changed the system.onPlayerConnected() hook

--- a/doc/DEMO_MUDLIB.md
+++ b/doc/DEMO_MUDLIB.md
@@ -6,7 +6,7 @@ As noted in the [Customization guide](CUSTOMIZING.md), which the reader is assum
 
 > The term "mudlib" refers to the very basic set of objects and entities that are initally required to make the first real objects in your game (i.e. the base structure for rooms, containers, behaviors, etc.). The demonstration comes with its own mudlib, which you can modify/extend, but it is wholly replaceable -- By nature, the demonstration mudlib has been kept small (no character classes or combat system, for instance -- You'll have to design your owns).
 
-This memorandum describes the demonstration mudlib (i.e. *lib\_xxx* objects), which may be used as a sample for designing and implementing you own game logic. It is indeed a very small library (with only 10 base structures for items/rooms/NPCs, and 7 traits for behaviors).
+This memorandum describes the demonstration mudlib (i.e. *lib.xxx* objects), which may be used as a sample for designing and implementing you own game logic. It is indeed a very small library (with only 10 base structures for items/rooms/NPCs, and 7 traits for behaviors).
 
 ## Introduction
 
@@ -21,10 +21,10 @@ For each objects, this memorandum provides:
 
 ### Pure traits
 
-These objects are purely 'abstract' (i.e. they don't inherit from **lib\_root**), and are
+These objects are purely 'abstract' (i.e. they don't inherit from **lib.root**), and are
 intended to be added to objects, to extend their functionality.
 
-#### lib\_traits\_describable
+#### lib.traits.describable
 
 A trait for items than can be described.
 
@@ -54,7 +54,7 @@ Triggers:
 | --------------------------- | ------------- |
 | onExamine                   | Fired after object is looked at. |
 
-#### lib\_traits\_gettable
+#### lib.traits.gettable
 
 A trait for items that can be taken or dropped.
 
@@ -78,7 +78,7 @@ Properties: none
 
 Triggers: none, but that's probably missing (e.g. onDropItem/onTakeItem)
 
-#### lib\_traits\_closeable
+#### lib.traits.closeable
 
 A trait for items that can be opened/closed/locked/unlocked.
 
@@ -110,7 +110,7 @@ Properties:
 | --------------------------- | ------------- |
 | locked   : Boolean          | True if item is locked. Defaults to true. |
 | closed   : Boolean          | True if item is closed. Defaults to true. |
-| keySet   : Array.String     | Key identifiers (see **lib\_key** below) for locking/unlocking the object. Defaults to [ "masterkey" ]. |
+| keySet   : Array.String     | Key identifiers (see **lib.key** below) for locking/unlocking the object. Defaults to [ "masterkey" ]. |
 | autolocking : Boolean       | Optional flag. If true, the object will lock itself when being closed. |
 
 - If you don't want the object to be lockable/unlockable, set the keySet to an empty array,
@@ -125,7 +125,7 @@ Triggers:
 | onLock                      | Fired after object is locked. |
 | onUnlock                    | Fired after object is unlocked. |
 
-#### lib\_traits\_container
+#### lib.traits.container
 
 A trait for items that can serve as containers.
 
@@ -145,18 +145,18 @@ Functions:
 | --------------------------- | ------------- |
 | announcePutItemContainer    | Defines the message displayed in the room when an object is put into the container. |
 | announceTakeItemContainer   | Defines the message displayed in the room when the object is taken from the container. |
-| canAccept                   | Checks the container interior can be accessed. Currently only checks whether the container is closed, in case it also inherits from *lib\_traits\_closeable*. |
+| canAccept                   | Checks the container interior can be accessed. Currently only checks whether the container is closed, in case it also inherits from *lib.traits.closeable*. |
 | describeContents            | Returns the contents of the container. |
 
 Properties: none
 
-Triggers: none, but that's probably missing (or we should use onDropItem/onTakeItem if the instances has *lib\_traits\_gettable*)
+Triggers: none, but that's probably missing (or we should use onDropItem/onTakeItem if the instances has *lib.traits.gettable*)
 
-#### lib\_traits\_surface
+#### lib.traits.surface
 
 A trait for items that can serve as surfaces (e.g. a table).
 
-Traits: none (but overloads some methods from **lib\_traits\_describable**).
+Traits: none (but overloads some methods from **lib.traits.describable**).
 
 Verbs:
 
@@ -184,10 +184,10 @@ Properties:
 | maxItems                    | Maximum items that can be stored on the surface. Defaults to 10. |
 | destroyOnUse : Boolean      | True if the object should be destroyed after use. Defaults to false. |
 
-Triggers: none, but that's probably missing (or we should use onDropItem/onTakeItem if the instances has *lib\_traits\_gettable*)
+Triggers: none, but that's probably missing (or we should use onDropItem/onTakeItem if the instances has *lib.traits.gettable*)
 
 
-#### lib\_traits\_edible
+#### lib.traits.edible
 
 A trait for items that can be eaten or drunk.
 
@@ -204,7 +204,7 @@ Functions:
 | Function                    | Description   |
 | --------------------------- | ------------- |
 | doUse                       | Drinking/eating logic.  |
-| canUse                      | Check if eating/drinking is possible. Returns true, but intended to be overloaded by derived objects, e.g. see **lib\_ediblecontainer**. |
+| canUse                      | Check if eating/drinking is possible. Returns true, but intended to be overloaded by derived objects, e.g. see **lib.ediblecontainer**. |
 
 Properties:
 
@@ -215,7 +215,7 @@ Properties:
 | destroyOnUse : Boolean      | True if the object should be destroyed after use. Defaults to false. |
 
 - To keep this as simple as possible, edibled object are either single use (when destroyOnUse is true) or inexhaustible (when false).
-- See also **lib\_ediblecontainer** below, which is not destroyed when used, but handles its own exhaustion state.
+- See also **lib.ediblecontainer** below, which is not destroyed when used, but handles its own exhaustion state.
 
 Triggers:
 
@@ -223,7 +223,7 @@ Triggers:
 | --------------------------- | ------------- |
 | onUse                       | Fired after object is eaten or drunk. |
 
-#### lib\_traits\_commandable
+#### lib.traits.commandable
 
 A trait for locations (as opposed to the previous ones), using the special "verbMissing" property on locations, invoked by the game engine when a matching verb cannot be found according to the usual command processing rules. 
 
@@ -252,7 +252,7 @@ Properties:
 
 ### Root object
 
-#### lib\_root
+#### lib.root
 
 A base parent trait for all other objects.
 
@@ -269,11 +269,11 @@ Functions:
 
 ### Rooms and doors
 
-#### lib\_room
+#### lib.room
 
 The base structure for rooms.
 
-Traits: **lib\_root**
+Traits: **lib.root**
 
 Verbs:
 
@@ -311,13 +311,13 @@ Triggers:
 | onEnter                     | Fired after the room is entered. |
 | onLeave                     | Fired when the room is left. |
 
-#### lib\_door
+#### lib.door
 
 A door is a two-way traversable entity.
 
 For the reminder, once you have connected rooms via a door, you will very likely want to add the door to the extraMatchObjects property of each room, so that players can operate upon the door (since it is not an item in the room's contents).
 
-Traits: **lib\_root**, **lib\_traits\_describable**, **lib\_traits\_closeable**
+Traits: **lib.root**, **lib.traits.describable**, **lib.traits.closeable**
 
 Verbs: none
 
@@ -357,11 +357,11 @@ function onTraversal(player) {
 
 ### Items
 
-#### lib\_item
+#### lib.item
 
 The base structure for items.
 
-Traits: **lib\_root**, **lib\_traits\_describable**, **lib\_traits\_gettable**
+Traits: **lib.root**, **lib.traits.describable**, **lib.traits.gettable**
 
 Verbs: none
 
@@ -373,11 +373,11 @@ Properties:
 | --------------------------- | ------------- |
 | description : String        | Default textual description ("An undescript item.") |
 
-#### lib\_key
+#### lib.key
 
 A base object for designing key-like items, allowing to lock/unlock closeable objects.
 
-Traits: **lib\_item**
+Traits: **lib.item**
 
 Verbs: none
 
@@ -390,13 +390,13 @@ Properties:
 | description : String        | Default textual description ("An undescript key.") |
 | keyId : String              | Default key identifier for matching closeable objects ("masterkey") |
 
-- The key identifier is set to "masterkey", which is also the initial setting for **lib\_traits\_closeable**, so any derived object will by default be an all-purpose master key. It is up to you to change it, following you own identification pattern.
+- The key identifier is set to "masterkey", which is also the initial setting for **lib.traits.closeable**, so any derived object will by default be an all-purpose master key. It is up to you to change it, following you own identification pattern.
  
-#### lib\_ediblecontainer
+#### lib.ediblecontainer
 
 A base object for designing single use items containing edible things, such as a cup of tea, a plate of potatoes, etc. When used, they become an empty cup, an empty plate, etc.
 
-Traits: **lib\_item**, **lib\_traits\_edible**
+Traits: **lib.item**, **lib.traits.edible**
 
 Verbs: none
 
@@ -420,11 +420,11 @@ Properties:
 
 ### Living things
 
-#### lib\_player
+#### lib.player
 
 The base structure for players.
 
-Traits: **lib\_root**, **lib\_traits\_describable**
+Traits: **lib.root**, **lib.traits.describable**
 
 Verbs:
 
@@ -454,13 +454,13 @@ Properties:
 | --------------------------- | ------------- |
 | mode : WorldObject          | Current mode (play, say, chat, eval). |
 
-#### lib\_npc
+#### lib.npc
 
 The base structure for non-player characters. This is just a demonstration, so we do not
 really know what NPCs are - but we will eventually want them to have extra features in the
 future, so this object is kind of a place holder for now.
 
-Traits: **lib\_root**, **lib\_traits\_describable**
+Traits: **lib.root**, **lib.traits.describable**
 
 Verbs: none
 
@@ -468,15 +468,15 @@ Functions: none
 
 Properties: none
 
-#### lib\_npc\_seller
+#### lib.npcs.seller
 
 The base structure for (very simple) NPC sellers. The 'list' command allows getting the list of goods, and the 'order' command to obtain one of the listed goods.
 
 The goods available for sale are those in the object's contents (so logically you would want to have different types of items there). Upon order, the required object is cloned and the newly created instance is given to the player (i.e. placed in the player's contents).
 
-For this to work, the NPC must be in a room that has the **lib\_traits\_commandable** trait, for the player commands to be delegated to the NPC.
+For this to work, the NPC must be in a room that has the **lib.traits.commandable** trait, for the player commands to be delegated to the NPC.
 
-Traits: **lib\_npc**
+Traits: **lib.npc**
 
 Verbs:
 

--- a/doc/PROGRAMMING.md
+++ b/doc/PROGRAMMING.md
@@ -14,9 +14,9 @@ You can then use any JavaScript (ES6) construct to start creating new rooms and 
 - Toplevel functions: there are a few global functions, such as **all()**. Some are seldom used in actual code, but are provided as utilities for you to invoke on the command line. Others, such as **nextId()**, will be of more frequent use.
 - World objects:
   - Each object in the world has a unique identifier, which also corresponds to its name in the global scope.
-    - You may reference an object by its identifier: `$('lib_room')`
-    - Or rather, directy by its global variable:  `lib_room`
-    - Identifiers are internally mapped to a file path by the DB, with the underscore character corresponding to the path separator (e.g. "lib\_room" will be mapped to "lib/room"). This allows  organizing the objects logically -- You can create objects at any level, but it is a **good practice** to enquire your game administrator regarding the recommended naming scheme. Please also refer to the [Customization guide](CUSTOMIZING.md)
+    - You may reference an object by its identifier: `$('lib.room')`
+    - Or rather, directy by its global variable:  `lib.room`
+    - Identifiers are internally mapped to a file path by the DB, with the underscore character corresponding to the path separator (e.g. "lib.room" will be mapped to "lib/room"). This allows  organizing the objects logically -- You can create objects at any level, but it is a **good practice** to enquire your game administrator regarding the recommended naming scheme. Please also refer to the [Customization guide](CUSTOMIZING.md)
   - Objects can include, as usual, properties and functions, but they can also have verbs.
     - To add a new function: `obj.foo = function foo()` {} 
     - To add a new verb: `obj.bar = Verb("bar")`
@@ -31,29 +31,29 @@ For more details, see also the [Reference guide](#reference-guide) further below
 But for now, let's create our first object: a (very) basic lantern!
 First, switch to EVAL mode, so that you do not have to prefix every JavaScript command.
 
-- Create a new object. In the demonstration mudlib, **lib\_item** is a gettable and describable object. So we will start from it (i.e. it will be the base trait for our object)
+- Create a new object. In the demonstration mudlib, **lib.item** is a gettable and describable object. So we will start from it (i.e. it will be the base trait for our object)
 ```javascript
-lib_item.new('tests_lantern');
+lib.item.new('tests.lantern');
 ```
 - By default, its short name is the same as its identifier, and it doesn't have a long description. It doesn't have aliases either. This is not very convenient, so let's add all these things:
 ```javascript
-tests_lantern.name = "lantern";
-tests_lantern.addAlias("lamp");
-tests_lantern.description = "a portable lamp in a case, protected from the wind and rain";
+tests.lantern.name = "lantern";
+tests.lantern.addAlias("lamp");
+tests.lantern.description = "a portable lamp in a case, protected from the wind and rain";
 ```
 - Since it is intended for being lit, let's add a boolean property to keep track of that state:
 ```javascript
-tests_lantern.lighted = false; 
+tests.lantern.lighted = false; 
 ```
 - This is a step-by-step example, but actually note that we could rather have added most of the properties directly at creation, specified as options:
 ```javascript
-lib_item.new('tests_lantern', { name: "lantern", lighted: false });
+lib.item.new('tests.lantern', { name: "lantern", lighted: false });
 ```
 
 - Anyhow, let's now declare the available command verbs:
 ```javascript
-tests_lantern.light = Verb("light", "this", "none", "none");
-tests_lantern.extinguish = Verb("extinguish", "this", "none", "none");
+tests.lantern.light = Verb("light", "this", "none", "none");
+tests.lantern.extinguish = Verb("extinguish", "this", "none", "none");
 ```
 - Hit Ctrl-p and look for our newly created "light" verb. In the editor, copy the following function body into the default template (i.e. keep the surrounding function definition!)
 ```javascript
@@ -73,8 +73,8 @@ tests_lantern.extinguish = Verb("extinguish", "this", "none", "none");
 ```
 - Close the editing tabs and return to the MUD tab. Here, for the sake of illustration, we decided to use two additional functions, that will be responsible for changing the state flag and announce something to other people in the room. So let's first create them:
 ```javascript
-tests_lantern.doLight = function(player) {};
-tests_lantern.doExtinguish = function(player) {};
+tests.lantern.doLight = function(player) {};
+tests.lantern.doExtinguish = function(player) {};
 ```
 - And again, hit Ctrl-p and look for these functions. Insert the following content inside the body for the doLight method, and save with Ctrl-s:
 ```javascript
@@ -106,7 +106,7 @@ tests_lantern.doExtinguish = function(player) {};
 ```
 - Go back to the MUD tab. We will want to test our new object, so let's bring it to our current room (and notice how the *this* object conveniently here points to you, the player/builder):
 ```javascript
-tests_lantern.location = this.location
+tests.lantern.location = this.location
 ```
 
 - Leave the EVAL mode, and play:
@@ -240,7 +240,7 @@ Creates a new world object, deriving from its parent (i.e. having it in its trai
 
 Example:
 ```javascript
-lib_chest.new("items_chest2", { name: "large chest", opened: false, locked: false });
+lib.chest.new("items.chest2", { name: "large chest", opened: false, locked: false });
 ```
 
 Note: The identifier is 'sanitized', i.e. non-authorized characters are removed or replaced.
@@ -303,7 +303,7 @@ Returns:
 #### Verb related methods
 For advanced usage. 
 
-Check the **items\_builderstaff** item or the **lib\_traits\_commandable** trait in the demonstration for possible use cases. 
+Check the **items.builderstaff** item or the **lib.traits.commandable** trait in the demonstration for possible use cases. 
 
 ##### matchObjects( command : String ) ⇒ Object
 Given a command, returns { dobj : WorldObject, iobj : WorldObject }, containing the matched objects in the environment.
@@ -317,7 +317,7 @@ They exist in the execution context, but are probably of lower interest.
 ##### send( String\|Object ) ⇒ Boolean
 Sends a message to the client.
 
-This is normally not intended to be used directly (e.g. check the **tell()** method, defined by the **lib\_root** object inherited by allmost all objects in the demo mudlib).
+This is normally not intended to be used directly (e.g. check the **tell()** method, defined by the **lib.root** object inherited by allmost all objects in the demo mudlib).
 
 Returns true upon success, false upon failure (no controller, e.g. not a player, or player not connected). 
 


### PR DESCRIPTION
Documentation and demonstration fixes only: some underscore characters remaining here and there (breaking a few things in the demo such as object cloning at seller or with staff, and not so obvious message propagation between two rooms).