### PR TITLE
Add robustness check to request-input responses #173

### DIFF
--- a/src/controllers/unauthenticated-user-controller.js
+++ b/src/controllers/unauthenticated-user-controller.js
@@ -32,7 +32,15 @@ class UnauthenticatedUserController extends BaseChildController {
       { type: 'password', label: 'repeat password', name: 'password2' }
     ]
 
-    this.emit('request-input', inputs, ({ username, password, password2 }) => {
+    this.emit('request-input', inputs, reply => {
+      if (!reply ||
+          typeof reply.password !== 'string' || typeof reply.username !== 'string') {
+        this.emit('output', red('Invalid client response.'))
+        return
+      }
+
+      const { username, password, password2 } = reply
+
       const sanitizedUsername = username.trim()
       const user = this.userDb.findById(sanitizedUsername)
 
@@ -82,7 +90,15 @@ class UnauthenticatedUserController extends BaseChildController {
       { type: 'password', label: 'password', name: 'password' }
     ]
 
-    this.emit('request-input', inputs, ({ username, password }) => {
+    this.emit('request-input', inputs, reply => {
+      if (!reply ||
+          typeof reply.password !== 'string' || typeof reply.username !== 'string') {
+        this.emit('output', red('Invalid client response.'))
+        return
+      }
+
+      const { password, username } = reply
+
       const sanitizedUsername = username.trim()
       const user = this.userDb.findById(sanitizedUsername)
 

--- a/src/controllers/user-controller.js
+++ b/src/controllers/user-controller.js
@@ -43,13 +43,19 @@ class UserController extends BaseChildController {
       { type: 'text', label: 'player name', name: 'playerName' }
     ]
 
-    this.emit('request-input', inputs, ({ playerName }) => {
+    this.emit('request-input', inputs, reply => {
+      if (!reply || typeof reply.playerName !== 'string') {
+        this.emit('output', red('Invalid client response.'))
+        return
+      }
+
       const PLAYERS_HIERARCHY = 'players.'
 
       // Create unique ID:
       // We want to place player id under the 'players.' logical hierarchy.
       // Use playerName as base, but remove dots to disallow additional logical levels.
       // Call nextId() to obtain a unique sanitized ID.
+      const { playerName } = reply
       const playerId = this.world.nextId(PLAYERS_HIERARCHY + playerName.replace(/\./g, ''))
       // However, if the playerName is reduced to '' by the sanitizing, the final dot may get.
       // trimmed.
@@ -100,7 +106,13 @@ class UserController extends BaseChildController {
       })
 
       this.emit('output', msg.join('\n'))
-      this.emit('request-input', inputs, ({ selection }) => {
+      this.emit('request-input', inputs, reply => {
+        if (!reply || typeof reply.selection !== 'string') {
+          this.emit('output', red('Invalid client response.'))
+          return
+        }
+
+        const { selection } = reply
         const n = parseInt(selection, 10)
 
         const lowerCaseNames = players.map(p => p.name.toLowerCase())

--- a/test/blackbox/authenticated-test.js
+++ b/test/blackbox/authenticated-test.js
@@ -74,6 +74,48 @@ authenticatedTest('room.js: as an authenticated user, create player; existing na
   })
 })
 
+authenticatedTest('room.js: as an authenticated user, create player; robustness check (non-string name)', (t, { server, socket, end }) => {
+  insertTestPlayer(server)
+  socket.emit('input', 'create')
+
+  socket.once('request-input', (inputs, send) => {
+    const expectedInputs = [ { label: 'player name', name: 'playerName', type: 'text' } ]
+
+    t.deepEqual(inputs, expectedInputs)
+
+    send({ playerName: null })
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+authenticatedTest('room.js: as an authenticated user, create player; robustness check (invalid reply)', (t, { server, socket, end }) => {
+  insertTestPlayer(server)
+  socket.emit('input', 'create')
+
+  socket.once('request-input', (inputs, send) => {
+    const expectedInputs = [ { label: 'player name', name: 'playerName', type: 'text' } ]
+
+    t.deepEqual(inputs, expectedInputs)
+
+    send(1234)
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
 authenticatedTest('room.js: as an authenticated user, invalid command', (t, { server, socket, end }) => {
   socket.emit('input', 'invalidcommand')
 
@@ -193,6 +235,66 @@ authenticatedTest('room.js: as an authenticated user, play w/ multiple character
 
       socket.once('output', (msg) => {
         const expected = 'Invalid selection.'
+        const actual = stripAnsi(msg)
+
+        t.equal(actual, expected)
+        end()
+      })
+    })
+  })
+})
+
+authenticatedTest('room.js: as an authenticated user, play w/ multiple characters to pick from; robustness check (non-string selection)', (t, { server, socket, end }) => {
+  insertTestPlayer(server)
+  insertTestPlayer(server, 'bob', 'test')
+
+  socket.emit('input', 'play')
+
+  socket.once('output', (msg) => {
+    const expected = 'Choose a character to play as:\n1. #cmd[test]\n2. #cmd[bob]'
+    const actual = msg
+
+    t.equal(actual, expected)
+
+    socket.once('request-input', (inputs, send) => {
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+
+      t.deepEqual(inputs, expectedInputs)
+
+      send({ selection: 1 })
+
+      socket.once('output', (msg) => {
+        const expected = 'Invalid client response.'
+        const actual = stripAnsi(msg)
+
+        t.equal(actual, expected)
+        end()
+      })
+    })
+  })
+})
+
+authenticatedTest('room.js: as an authenticated user, play w/ multiple characters to pick from; robustness check (invalid reply)', (t, { server, socket, end }) => {
+  insertTestPlayer(server)
+  insertTestPlayer(server, 'bob', 'test')
+
+  socket.emit('input', 'play')
+
+  socket.once('output', (msg) => {
+    const expected = 'Choose a character to play as:\n1. #cmd[test]\n2. #cmd[bob]'
+    const actual = msg
+
+    t.equal(actual, expected)
+
+    socket.once('request-input', (inputs, send) => {
+      const expectedInputs = [ { type: 'text', label: 'character', name: 'selection' } ]
+
+      t.deepEqual(inputs, expectedInputs)
+
+      send(1234)
+
+      socket.once('output', (msg) => {
+        const expected = 'Invalid client response.'
         const actual = stripAnsi(msg)
 
         t.equal(actual, expected)

--- a/test/blackbox/programming-test.js
+++ b/test/blackbox/programming-test.js
@@ -170,3 +170,87 @@ programmerTest('room.js: as a programmer, eval code that throws an error', (t, {
     end()
   })
 })
+
+programmerTest('room.js: as a programmer, eval code that creates/destroys an object', (t, { server, socket, end }) => {
+  socket.emit('input', 'eval root.new(\'rootx\')')
+
+  socket.once('output', (msg) => {
+    const expected = '{ id: \'rootx\',\n  name: \'rootx\',\n  aliases: [],\n  traits: [Array(1)],\n  location: null,\n  contents: [] }'
+    const actual = stripAnsi(msg)
+
+    t.equal(actual, expected)
+
+    socket.emit('input', 'eval rootx.id')
+
+    socket.once('output', (msg) => {
+      const expected = '\'rootx\''
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+
+      socket.emit('input', 'eval rootx.destroy()')
+
+      socket.once('output', (msg) => {
+        const expected = 'true'
+        const actual = stripAnsi(msg)
+
+        t.equal(actual, expected)
+        end()
+      })
+    })
+  })
+})
+
+programmerTest('room.js: as a programmer, eval code that creates/destroys an object; with properties', (t, { server, socket, end }) => {
+  socket.emit('input', 'eval root.new(\'rootx\', { prop: 1234 })')
+
+  socket.once('output', (msg) => {
+    const expected = '{ id: \'rootx\',\n  name: \'rootx\',\n  aliases: [],\n  traits: [Array(1)],\n  location: null,\n  contents: [],\n  prop: 1234 }'
+    const actual = stripAnsi(msg)
+
+    t.equal(actual, expected)
+
+    socket.emit('input', 'eval rootx.id')
+
+    socket.once('output', (msg) => {
+      const expected = '\'rootx\''
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+
+      socket.emit('input', 'eval rootx.destroy()')
+
+      socket.once('output', (msg) => {
+        const expected = 'true'
+        const actual = stripAnsi(msg)
+
+        t.equal(actual, expected)
+        end()
+      })
+    })
+  })
+})
+
+programmerTest('room.js: as a programmer, eval code that creates an object; id already exists', (t, { server, socket, end }) => {
+  socket.emit('input', 'eval root.new(\'root\')')
+
+  socket.once('output', (msg) => {
+    const expected = /TypeError: Identifier 'root' has already been declared/
+    const actual = stripAnsi(msg)
+
+    t.ok(expected.test(actual))
+    end()
+  })
+})
+
+programmerTest('room.js: as a programmer, eval code that destroys an object; cannot destroy online player', (t, { server, socket, end }) => {
+  socket.emit('input', 'eval this.destroy()')
+
+  socket.once('output', (msg) => {
+    const expected = /Error: test is a player and is online/
+    const actual = stripAnsi(msg)
+
+    t.ok(expected.test(actual))
+    end()
+  })
+})

--- a/test/blackbox/unauthenticated-test.js
+++ b/test/blackbox/unauthenticated-test.js
@@ -71,6 +71,54 @@ unauthenticatedTest('room.js: as an unauthenticated user, attempt to create a us
   })
 })
 
+unauthenticatedTest('room.js: as an unauthenticated user, attempt to create a user, robustness check (non-string password)', (t, { server, socket, end }) => {
+  socket.emit('input', 'create')
+
+  socket.once('request-input', (inputs, send) => {
+    send({ username: 'testbadpass', password: null, password2: null })
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+unauthenticatedTest('room.js: as an unauthenticated user, attempt to create a user, robustness check (non-string username)', (t, { server, socket, end }) => {
+  socket.emit('input', 'create')
+
+  socket.once('request-input', (inputs, send) => {
+    send({ username: null, password: 'testbaduser', password2: 'testbaduser' })
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+unauthenticatedTest('room.js: as an unauthenticated user, attempt to create a user, robustness check (invalid reply)', (t, { server, socket, end }) => {
+  socket.emit('input', 'create')
+
+  socket.once('request-input', (inputs, send) => {
+    send(1234)
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
 unauthenticatedTest('room.js: as an unauthenticated user, login', (t, { server, socket, end }) => {
   insertTestUser(server)
 
@@ -124,6 +172,60 @@ unauthenticatedTest('room.js: as an unauthenticated user, login attempt for non-
 
     socket.once('output', (msg) => {
       const expected = 'Invalid username or password.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+unauthenticatedTest('room.js: as an unauthenticated user, login attempt, robustness check (non-string password)', (t, { server, socket, end }) => {
+  insertTestUser(server)
+
+  socket.emit('input', 'login')
+
+  socket.once('request-input', (_, send) => {
+    send({ username: 'test', password: null })
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+unauthenticatedTest('room.js: as an unauthenticated user, login attempt, robustness check (non-string username)', (t, { server, socket, end }) => {
+  insertTestUser(server)
+
+  socket.emit('input', 'login')
+
+  socket.once('request-input', (_, send) => {
+    send({ username: null, password: 'test' })
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
+      const actual = stripAnsi(msg)
+
+      t.equal(actual, expected)
+      end()
+    })
+  })
+})
+
+unauthenticatedTest('room.js: as an unauthenticated user, login attempt, robustness check (invalid reply)', (t, { server, socket, end }) => {
+  insertTestUser(server)
+
+  socket.emit('input', 'login')
+
+  socket.once('request-input', (_, send) => {
+    send(1234)
+
+    socket.once('output', (msg) => {
+      const expected = 'Invalid client response.'
       const actual = stripAnsi(msg)
 
       t.equal(actual, expected)


### PR DESCRIPTION
Just ensure clients provide the expected response payloads.

Closes #173